### PR TITLE
Re-enable darwin build of python module moderngl, now that mesa is available on Darwin

### DIFF
--- a/pkgs/development/python-modules/moderngl/default.nix
+++ b/pkgs/development/python-modules/moderngl/default.nix
@@ -7,6 +7,7 @@
   setuptools,
   glcontext,
   pythonOlder,
+  mesa
 }:
 
 buildPythonPackage rec {
@@ -47,7 +48,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/moderngl/moderngl/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ c0deaddict ];
-    # should be mesa.meta.platforms, darwin build breaks.
-    platforms = platforms.linux;
+    platforms = mesa.meta.platforms;
   };
 }


### PR DESCRIPTION
Updated platforms to enable build on darwin, as was previously blocked by mesa.

Now that mesa builds on Darwin (see https://github.com/NixOS/nixpkgs/pull/319047), we can try enabling build of moderngl too (see https://github.com/NixOS/nixpkgs/issues/372030). This should work towards fixing manim (see https://github.com/NixOS/nixpkgs/issues/372032).

This is my first pull request, I'm going to try running nixpkgs-review against it next. 

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
